### PR TITLE
Switch back to Docker using Py3.7

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+__pycache__/
+*.pyc
+venv/
+env/
+.mypy_cache/
+.vscode/
+.idea/

--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -11,26 +11,7 @@ jobs:
   run_slapr:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.8'
-    - name: Cache pip
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip # This path is specific to Ubuntu
-        # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
-    - name: Install dependencies
-      run: pip install -r requirements.txt
-    - name: Run Slapr
-      run: |
-        python --version
-        python -m slapr
+    - uses: DataDog/hackadog-slapr@master
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         GITHUB_REPO: DataDog/hackadog-slapr

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+# Use 3.7 instead of 3.8 for faster builds (a.k.a. The Wheels Problem™).
+FROM python:3.7
+
+COPY requirements.txt /
+RUN pip install -r /requirements.txt
+
+COPY slapr/ /slapr/
+
+ENTRYPOINT [ "python", "-m", "slapr" ]

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,5 @@
+name: 'Hack-A-Dog Slapr'
+description: 'Add emoji on Slack posts on PR updates'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'


### PR DESCRIPTION
Using Docker allows us to put the entire build config in the Action, instead of users having to copy-paste code to setup Python and the cache.

Python 3.8 is missing some of the wheels we need so the packages have to be re-compiled. This PR uses 3.7 where wheels are widely available.