### PR TITLE
Update Slack API call from channels_history to conversations_history

### DIFF
--- a/slapr/slack.py
+++ b/slapr/slack.py
@@ -35,7 +35,7 @@ class WebSlackBackend(SlackBackend):
         self._client = client
 
     def get_latest_messages(self, channel_id: str) -> List[Message]:
-        response = self._client.channels_history(channel=channel_id)
+        response = self._client.conversations_history(channel=channel_id)
         assert response["ok"]
         return [
             Message(text=message.get("text", ""), timestamp=message["ts"])


### PR DESCRIPTION
Motivation: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api

CI Error: https://github.com/DataDog/integrations-core/pull/8693/checks?check_run_id=1977864243
> The server responded with: {'ok': False, 'error': 'method_deprecated', 'response_metadata': {'messages': ['[ERROR] This method is retired and can no longer be used. Please use conversations.history instead. Learn more: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api.']}}