### PR TITLE
feat(github): Force default permissions of GITHUB_TOKEN

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 # Rules are matched bottom-to-top, so one team can own subdirectories
 # and another the rest of the directory.
 
-/.*                                     @DataDog/agent-platform
+/.*                                     @DataDog/agent-devx-loops

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -3,6 +3,8 @@ name: Python Tests
 
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -12,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
 

--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     types: [closed]
 
+permissions: {}
+
 jobs:
   run_slapr:
     runs-on: ubuntu-latest

--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: DataDog/slapr@master
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        SLACK_CHANNEL_ID: CNY5XCHAA
+        SLACK_CHANNEL_ID: C06P4TAJ2Q6
         SLACK_API_TOKEN: "${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}"
         SLAPR_BOT_USER_ID: UTMS06TPX
         SLAPR_EMOJI_REVIEW_STARTED: "review_started"


### PR DESCRIPTION
### What does this PR do?
[ACIX-407](https://datadoghq.atlassian.net/browse/ACIX-407?atlOrigin=eyJpIjoiMDU2M2QxNTM0NTgzNGUwZTg3NDc1YjIwZmJlMzk4NTciLCJwIjoiaiJ9)
[VULN-8175](https://datadoghq.atlassian.net/browse/VULN-8175)

Github token permissions should follow the [least privilege principle](https://datadoghq.atlassian.net/wiki/x/TIVE6Q)
Reset workflow permissions to validate we can enable Read-only default permissions at repository level to provide a strong baseline protection measure

Also update ownership and slack channel id to [#agent-devx-loops](https://dd.enterprise.slack.com/archives/C06P4TAJ2Q6)

> [!NOTE]
Test on unit_tests [status](https://github.com/DataDog/slapr/actions/runs/10598889732/job/29372546567?pr=48) and slapr status


[ACIX-407]: https://datadoghq.atlassian.net/browse/ACIX-407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[VULN-8175]: https://datadoghq.atlassian.net/browse/VULN-8175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ