### PR TITLE
Dockerfile: change base to `python:3.10`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/)
 # Copyright 2023-present Datadog, Inc.
 
-# Use 3.7 instead of 3.8 for faster builds (a.k.a. The Wheels Problem™).
-FROM python:3.7
+FROM python:3.10
 
 WORKDIR /app
 COPY setup.py /app/


### PR DESCRIPTION
### What does this PR do?

Update the base image in Dockerfile from `python:3.7` to `python:3.10`

### Motivation

Fix errors during docker build&mdash;causing errors during GitHub actions

```
ERROR: Package 'slapr' requires a different Python: 3.7.17 not in '>=3.10'
```

### Describe how you validated your changes

* Unit tests passing: https://github.com/bennettp123/slapr/actions/runs/23286163852/job/67710048499
* Also confirmed inside docker container using `docker build -t slapr . && docker run --rm -it --entrypoint bash -v "${PWD}:/workspace" -w /workspace slapr -c "pip install pytest pytest-cov && pytest"`:
    <img width="1398" height="1285" alt="image" src="https://github.com/user-attachments/assets/6219dad3-d022-4536-b0f1-ecc403c34729" />


### Additional Notes

Minimum python version was [updated here](https://github.com/DataDog/slapr/commit/099b695b7d2a10263c6918c58b022c3ccbdef4d5#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R13)