### PR TITLE
fix(github): Use Auth.Token instead of deprecated login_or_token

### DIFF
--- a/slapr/__main__.py
+++ b/slapr/__main__.py
@@ -30,7 +30,7 @@ config = Config(
     slack_client=slack_client,
     github_client=GithubClient(
         backend=WebGithubBackend(
-            gh=github.Github(os.environ["GITHUB_TOKEN"]),
+            gh=github.Github(auth=github.Auth.Token(os.environ["GITHUB_TOKEN"])),
             event_path=os.environ["GITHUB_EVENT_PATH"],
             repo=os.environ["GITHUB_REPOSITORY"],
         )


### PR DESCRIPTION
## Summary
- Replace deprecated `Github(token)` positional argument with `Github(auth=github.Auth.Token(token))` to fix PyGithub 2.x deprecation warning

## Context
The deprecation warning was spotted in [this workflow run](https://github.com/DataDog/datadog-agent/actions/runs/23288682931/job/67718434053?pr=47839):
```
DeprecationWarning: Argument login_or_token is deprecated, please use auth=github.Auth.Token(...) instead
```

## Test plan
- [x] All 24 existing tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)