### PR TITLE
ci: Add Docker layer caching to build job

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -35,8 +35,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Build Docker image
-        run: docker build -t slapr:test .
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: .
+          load: true
+          tags: slapr:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Validate Docker image runs
         run: docker run --rm --entrypoint python slapr:test -c "import slapr; print('ok')"


### PR DESCRIPTION
## Summary
- Replace bare `docker build` with `docker/build-push-action` v7.0.0 + `docker/setup-buildx-action` v4.0.0
- Enable GitHub Actions cache (`type=gha,mode=max`) for Docker layer caching

## Test plan
- [ ] CI pipeline passes with cached Docker builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)