### PR TITLE
chore: Prevent crash when empty channel is defined in the slack map

### DIFF
--- a/slapr/main.py
+++ b/slapr/main.py
@@ -97,6 +97,9 @@ def _resolve_target_channels(
         if full_team not in review_map.team_to_channel:
             print(f"  Team {full_team}: not in review map, use default")
         channel_id = review_map.team_to_channel.get(full_team, config.slack_channel_id)
+        if not channel_id:
+            print(f"  Team {full_team}: no channel configured, notifications suppressed")
+            continue
         if pr.state == "closed":
             target_channels[channel_id].append(team)
         else:

--- a/slapr/review_map.py
+++ b/slapr/review_map.py
@@ -70,10 +70,14 @@ class ReviewMap:
             match entry:
                 case str() if entry == DEFAULT_SLACK_CHANNEL:
                     team_to_channel[team_key] = default_channel_id
-                case {"review": {"id": str(channel_id), **_rest}}:
+                case {"review": {"id": str(channel_id), **_rest}} if channel_id:
                     team_to_channel[team_key] = channel_id
-                case {"review": {"name": str(channel_name), **_rest}}:
+                case {"review": {"id": "", **_rest}}:
+                    print(f"Info: Empty channel id for {team}, notifications suppressed")
+                case {"review": {"name": str(channel_name), **_rest}} if channel_name:
                     teams_pending_resolve[channel_name].append(team_key)
+                case {"review": {"name": "", **_rest}}:
+                    print(f"Info: Empty channel name for {team}, notifications suppressed")
                 case {"review": dict()}:
                     print(f"Warning: 'review' for {team} has neither 'id' nor 'name', skipping")
                 case {"review": _}:
@@ -111,5 +115,7 @@ class ReviewMap:
         channels = set()
         for team in requested_teams:
             full_team = f"@{team.organization.login}/{team.slug}".lower()
-            channels.add(self.team_to_channel.get(full_team, self.default_channel_id))
+            channel_id = self.team_to_channel.get(full_team, self.default_channel_id)
+            if channel_id:
+                channels.add(channel_id)
         return channels

--- a/slapr/review_map.py
+++ b/slapr/review_map.py
@@ -91,8 +91,8 @@ class ReviewMap:
         if teams_pending_resolve:
             try:
                 name_to_id = slack_client.resolve_channel_names(set(teams_pending_resolve.keys()))
-            except SlackApiError as e:
-                print(f"Warning: Failed to resolve channel names via Slack API: {e}")
+            except (SlackApiError, RuntimeError) as e:
+                print(f"Warning: Failed to resolve channel names {set(teams_pending_resolve.keys())} via Slack API: {e}")
                 print("Entries without channel IDs will be skipped. "
                       "Add 'id' field to avoid this.")
                 name_to_id = {}

--- a/slapr/slack.py
+++ b/slapr/slack.py
@@ -45,7 +45,8 @@ class WebSlackBackend(SlackBackend):
 
     def get_latest_messages(self, channel_id: str) -> List[Message]:
         response = self._client.conversations_history(channel=channel_id)
-        assert response["ok"]
+        if not response["ok"]:
+            raise RuntimeError(f"conversations_history failed for channel {channel_id}: {response}")
         return [
             Message(text=message.get("text", ""), timestamp=message["ts"])
             for message in response["messages"]
@@ -54,7 +55,8 @@ class WebSlackBackend(SlackBackend):
 
     def get_reactions(self, timestamp: str, channel_id: str) -> List[Reaction]:
         response = self._client.reactions_get(channel=channel_id, timestamp=timestamp)
-        assert response["ok"]
+        if not response["ok"]:
+            raise RuntimeError(f"reactions_get failed for channel {channel_id}, timestamp {timestamp}: {response}")
 
         if response["type"] != "message":
             return []
@@ -68,13 +70,16 @@ class WebSlackBackend(SlackBackend):
         except SlackApiError as e:
             if e.response['error'] == 'already_reacted':
                 print(f'Warning: Message {timestamp} has already emote {emoji} within channel {channel_id}')
-                # Ignore already reacted errors
-                pass
             else:
+                print(f'Error: reactions_add failed for channel {channel_id}, emoji {emoji}, timestamp {timestamp}: {e}')
                 raise
 
     def remove_reaction(self, timestamp: str, emoji: str, channel_id: str) -> None:
-        self._client.reactions_remove(channel=channel_id, name=emoji, timestamp=timestamp)
+        try:
+            self._client.reactions_remove(channel=channel_id, name=emoji, timestamp=timestamp)
+        except SlackApiError as e:
+            print(f'Error: reactions_remove failed for channel {channel_id}, emoji {emoji}, timestamp {timestamp}: {e}')
+            raise
 
     def resolve_channel_names(self, names: Set[str]) -> Dict[str, str]:
         """Resolve channel names to channel IDs using conversations_list with pagination."""
@@ -86,7 +91,8 @@ class WebSlackBackend(SlackBackend):
             if cursor:
                 kwargs["cursor"] = cursor
             response = self._client.conversations_list(**kwargs)
-            assert response["ok"]
+            if not response["ok"]:
+                raise RuntimeError(f"conversations_list failed while resolving {names}: {response}")
             for channel in response["channels"]:
                 if channel["name"] in remaining:
                     result[channel["name"]] = channel["id"]

--- a/tests/test_review_map.py
+++ b/tests/test_review_map.py
@@ -228,6 +228,79 @@ def test_load_notification_ignored():
     assert review_map.team_to_channel == {"@datadog/agent-apm": "C_REVIEW"}
 
 
+def test_load_empty_channel_id_suppresses_notifications(capsys):
+    """Empty channel id should suppress notifications for that team (not crash)."""
+    yaml_content = """
+'@datadog/agent-apm':
+  review:
+    name: 'apm-review'
+    id: 'C_APM'
+'@datadog/agent-config':
+  review:
+    id: ''
+"""
+    slack_client = _make_slack_client({})
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(yaml_content)
+        f.flush()
+        review_map = ReviewMap.load(f.name, slack_client, default_channel_id="C_DEFAULT")
+
+    os.unlink(f.name)
+
+    assert review_map.team_to_channel == {"@datadog/agent-apm": "C_APM"}
+    assert "suppressed" in capsys.readouterr().out
+
+
+def test_load_empty_channel_name_suppresses_notifications(capsys):
+    """Empty channel name should suppress notifications for that team (not crash)."""
+    yaml_content = """
+'@datadog/agent-apm':
+  review:
+    name: 'apm-review'
+    id: 'C_APM'
+'@datadog/agent-config':
+  review:
+    name: ''
+"""
+    slack_client = _make_slack_client({})
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(yaml_content)
+        f.flush()
+        review_map = ReviewMap.load(f.name, slack_client, default_channel_id="C_DEFAULT")
+
+    os.unlink(f.name)
+
+    assert review_map.team_to_channel == {"@datadog/agent-apm": "C_APM"}
+    assert "suppressed" in capsys.readouterr().out
+
+
+def test_get_channels_for_requested_teams_skips_suppressed_team():
+    """Teams not in the map still use default, but teams explicitly suppressed are excluded."""
+    review_map = ReviewMap(
+        team_to_channel={
+            "@datadog/agent-apm": "C_APM",
+        },
+        default_channel_id="C_DEFAULT",
+    )
+
+    class FakeOrg:
+        login = "datadog"
+
+    class FakeTeam:
+        def __init__(self, slug):
+            self.slug = slug
+            self.organization = FakeOrg()
+
+    # Team not in map → falls back to default
+    assert review_map.get_channels_for_requested_teams([FakeTeam("unknown-team")]) == {"C_DEFAULT"}
+
+    # When default_channel_id is None, unknown teams produce no channel
+    review_map_no_default = ReviewMap(team_to_channel={}, default_channel_id=None)
+    assert review_map_no_default.get_channels_for_requested_teams([FakeTeam("unknown-team")]) == set()
+
+
 def test_load_multiple_teams_same_channel_name():
     """Multiple teams sharing the same review channel name should all map correctly."""
     yaml_content = """


### PR DESCRIPTION
### What does this PR do?
- Prevent crash when empty channel is defined in the slack map
- Improve crashes to always return channel information

### Motivation
Maintenance

### Describe how you validated your changes
Added some unit tests

### Additional Notes

