### PR TITLE
Fix PR link matching after Slack mentions

### DIFF
--- a/slapr/slack.py
+++ b/slapr/slack.py
@@ -9,7 +9,7 @@ from typing import Dict, List, NamedTuple, Optional, Set
 import slack_sdk
 from slack_sdk.errors import SlackApiError
 
-PR_URL_PATTERN = r"<(?P<url>.*)>"
+PR_URL_PATTERN = r"<(?P<url>https?://[^>|]+)(?:\|[^>]*)?>"
 
 
 class Message(NamedTuple):
@@ -111,20 +111,14 @@ class SlackClient:
         messages = self._backend.get_latest_messages(channel_id=channel_id)
 
         for message in messages:
-            match = re.search(PR_URL_PATTERN, message.text)
+            for match in re.finditer(PR_URL_PATTERN, message.text):
+                # Examples:
+                # https://github.com/owner/repo/pull/6/files
+                # https://github.com/owner/repo/pull/6/s
+                url = match.group("url")
 
-            if match is None:
-                continue
-
-            # Examples:
-            # https://github.com/owner/repo/pull/6/files
-            # https://github.com/owner/repo/pull/6/s
-            url = match.group("url")
-
-            if not url.startswith(pr_url):
-                continue
-
-            return message.timestamp
+                if url.startswith(pr_url):
+                    return message.timestamp
 
         return None
 

--- a/tests/test_slapr.py
+++ b/tests/test_slapr.py
@@ -183,6 +183,21 @@ MOCK_EVENT = {
             id="approval",
         ),
         pytest.param(
+            [
+                Message(
+                    text=(
+                        "<!subteam^S1234> CR Please - "
+                        "<https://github.com/example/repo/pull/42|github.com/example/repo/pull/42>"
+                    ),
+                    timestamp="yyyy-mm-dd",
+                )
+            ],
+            [Review(state="approved", user=_user("alice"))],
+            [],
+            ["test_review_started", "test_approved"],
+            id="approval-with-user-group-mention-before-link",
+        ),
+        pytest.param(
             [Message(text="Need :eyes: <https://github.com/example/repo/pull/42>", timestamp="yyyy-mm-dd")],
             [Review(state="changes_requested", user=_user("alice"))],
             [],


### PR DESCRIPTION
## Problem
A common Slack review request puts a user-group mention before the PR link:

```text
<!subteam^S1234> CR Please - <https://github.com/example/repo/pull/42|github.com/example/repo/pull/42>
```

The current greedy link expression captures from the mention opening bracket through the PR link closing bracket. Because that captured value no longer starts with the PR URL, Slapr logs `No message found requesting review`, exits successfully, and never adds the status reaction.

This means a natural mention-first review request silently loses its automation even though the workflow is green. Slapr should find the PR URL regardless of preceding Slack markup so a successful job reliably updates the message review state.

## Summary
- match each Slack-formatted HTTP link independently when locating a PR review request
- allow user-group mentions or other Slack markup before the PR URL
- add regression coverage for the observed message shape above

## Validation
- `/private/tmp/slapr-venv/bin/python -m pytest` (28 passed)
- `docker build -t slapr:codex-link-match-test .`
- `docker run --rm --entrypoint python slapr:codex-link-match-test -c "import slapr"`