### PR TITLE
Add a configurable partial approval emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Slack API Token with following permissions
 | emoji                        | description                                                  |
 |------------------------------|--------------------------------------------------------------|
 | `SLAPR_EMOJI_REVIEW_STARTED` | The PR has at least 1 in-progress review.                    |
+| `SLAPR_EMOJI_PARTIALLY_APPROVED` | The PR has approvals, but fewer than the configured minimum. |
 | `SLAPR_EMOJI_APPROVED`       | The PR has all required approvals and is ready to be merged. |
 | `SLAPR_EMOJI_NEEDS_CHANGES`  | Changes are requested for the PR.                            |
 | `SLAPR_EMOJI_COMMENTED`      | A review has been submitted with comment only.               |
@@ -84,15 +85,18 @@ jobs:
     steps:
     - uses: DataDog/slapr@master
       with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"
+        slack-api-token: "${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}"
+        slack-channel-id: CNY5XCHAA
+        bot-user-id: UTMS06TPX
         review-map: .github/review-map.yaml  # optional
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        GITHUB_REPO: DataDog/slapr
-        SLACK_CHANNEL_ID: CNY5XCHAA
-        SLACK_API_TOKEN: "${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}"
-        SLAPR_BOT_USER_ID: UTMS06TPX
-        SLAPR_NUMBER_OF_APPROVALS_REQUIRED: 2 # integer minimum=1 default=1. The number of approvals that are required for the approval emoji to be added in Slack
+        number-of-approvals-required: 2
+        emoji-partially-approved: next_track_button # :next_track_button:
+        emoji-approved: ship # :ship:
 ```
+
+`emoji-partially-approved` is opt-in. When it is not configured, approvals below
+the required count do not add a separate status emoji, preserving the existing behavior.
 
 ## Troubleshoot
 

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
     description: 'Emoji name for approved'
     required: false
     default: 'approved'
+  emoji-partially-approved:
+    description: 'Emoji name shown when approvals are present but below the required count'
+    required: false
   emoji-changes-requested:
     description: 'Emoji name for changes requested'
     required: false
@@ -56,6 +59,7 @@ runs:
     SLAPR_NUMBER_OF_APPROVALS_REQUIRED: ${{ inputs.number-of-approvals-required }}
     SLAPR_EMOJI_REVIEW_STARTED: ${{ inputs.emoji-review-started }}
     SLAPR_EMOJI_APPROVED: ${{ inputs.emoji-approved }}
+    SLAPR_EMOJI_PARTIALLY_APPROVED: ${{ inputs.emoji-partially-approved }}
     SLAPR_EMOJI_CHANGES_REQUESTED: ${{ inputs.emoji-changes-requested }}
     SLAPR_EMOJI_MERGED: ${{ inputs.emoji-merged }}
     SLAPR_EMOJI_CLOSED: ${{ inputs.emoji-closed }}

--- a/slapr/__main__.py
+++ b/slapr/__main__.py
@@ -44,6 +44,7 @@ config = Config(
     emoji_merged=os.environ.get("SLAPR_EMOJI_MERGED", "merged"),
     emoji_closed=os.environ.get("SLAPR_EMOJI_CLOSED", "closed"),
     emoji_commented=os.environ.get("SLAPR_EMOJI_COMMENTED", "comment"),
+    emoji_partially_approved=os.environ.get("SLAPR_EMOJI_PARTIALLY_APPROVED") or None,
     review_map=review_map,
 )
 

--- a/slapr/config.py
+++ b/slapr/config.py
@@ -26,6 +26,7 @@ class Config(NamedTuple):
     emoji_closed: str
     emoji_commented: str
 
+    emoji_partially_approved: Optional[str] = None
     review_map: Optional[ReviewMap] = None
 
     @property
@@ -38,9 +39,15 @@ class Config(NamedTuple):
             self.emoji_review_started,
             self.emoji_commented,
             self.emoji_needs_change,
-            self.emoji_approved,
-            self.emoji_closed,
-            self.emoji_merged,
         ]
+        if self.emoji_partially_approved:
+            review_steps_as_emojis.append(self.emoji_partially_approved)
+        review_steps_as_emojis.extend(
+            [
+                self.emoji_approved,
+                self.emoji_closed,
+                self.emoji_merged,
+            ]
+        )
 
         return lambda emoji: review_steps_as_emojis.index(emoji)

--- a/slapr/emojis.py
+++ b/slapr/emojis.py
@@ -3,7 +3,6 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/)
 # Copyright 2023-present Datadog, Inc.
 
-import itertools
 from typing import List, Optional, Set, Tuple
 
 from .github import Review
@@ -17,23 +16,19 @@ def select(
     number_of_approvals_required: int,
 ) -> Optional[str]:
 
-    all_reviews_by_author = {
-        user_login: list(author_reviews)
-        for user_login, author_reviews in itertools.groupby(reviews, key=lambda review: review.user.login)
-    }
+    last_review_by_author = {review.user.login: review for review in reviews}
 
     # Keep only reviews from authors belonging to the same team(s) as the reviewer
     if reviewer_teams:
-        reviews_by_author = {}
-        for author_login, author_reviews in all_reviews_by_author.items():
-            author_user = author_reviews[0].user
-            if any(t.has_in_members(author_user) for t in reviewer_teams):
-                reviews_by_author[author_login] = author_reviews
+        last_reviews = [
+            review
+            for review in last_review_by_author.values()
+            if any(team.has_in_members(review.user) for team in reviewer_teams)
+        ]
     else:
         # No review map or no team match: consider all reviews
-        reviews_by_author = all_reviews_by_author
+        last_reviews = list(last_review_by_author.values())
 
-    last_reviews = [reviews[-1] for reviews in reviews_by_author.values() if reviews]
     unique_states = {review.state for review in last_reviews}
 
     if "changes_requested" in unique_states:
@@ -42,6 +37,9 @@ def select(
     approval_count = len([review.state for review in last_reviews if review.state == "approved"])
     if ("approved" in unique_states) and approval_count >= number_of_approvals_required:
         return config.emoji_approved
+
+    if approval_count > 0 and config.emoji_partially_approved:
+        return config.emoji_partially_approved
 
     if "commented" in unique_states:
         return config.emoji_commented

--- a/tests/test_slapr.py
+++ b/tests/test_slapr.py
@@ -255,6 +255,88 @@ def test_on_pull_request_review(
 
 
 @pytest.mark.parametrize(
+    "reviews, reactions, partial_emoji, expected_emojis",
+    [
+        pytest.param(
+            [Review(state="approved", user=_user("alice"))],
+            [],
+            "test_partially_approved",
+            ["test_review_started", "test_partially_approved"],
+            id="approval-below-threshold",
+        ),
+        pytest.param(
+            [
+                Review(state="approved", user=_user("alice")),
+                Review(state="approved", user=_user("bob")),
+            ],
+            [Reaction(emoji="test_partially_approved", user_ids=["U1234"])],
+            "test_partially_approved",
+            ["test_review_started", "test_approved"],
+            id="approval-threshold-met",
+        ),
+        pytest.param(
+            [Review(state="approved", user=_user("alice"))],
+            [],
+            None,
+            ["test_review_started"],
+            id="partial-emoji-not-configured",
+        ),
+        pytest.param(
+            [
+                Review(state="approved", user=_user("alice")),
+                Review(state="commented", user=_user("bob")),
+            ],
+            [],
+            "test_partially_approved",
+            ["test_review_started", "test_partially_approved"],
+            id="partial-approval-takes-precedence-over-comment",
+        ),
+        pytest.param(
+            [
+                Review(state="approved", user=_user("alice")),
+                Review(state="changes_requested", user=_user("bob")),
+            ],
+            [Reaction(emoji="test_partially_approved", user_ids=["U1234"])],
+            "test_partially_approved",
+            ["test_review_started", "test_needs_change"],
+            id="changes-requested-takes-precedence",
+        ),
+    ],
+)
+def test_multiple_approvals(
+    reviews: List[Review],
+    reactions: List[Reaction],
+    partial_emoji: Optional[str],
+    expected_emojis: List[str],
+) -> None:
+    messages = [Message(text="Need review <https://github.com/example/repo/pull/42>", timestamp="yyyy-mm-dd")]
+    slack_backend = MockSlackBackend(messages=messages, target_message=messages[0], reactions=reactions)
+    github_backend = MockGithubBackend(
+        reviews=reviews,
+        event=MOCK_EVENT,
+        pr=PullRequest(state="open", merged=False, mergeable_state="clean"),
+    )
+
+    config = Config(
+        slack_client=SlackClient(backend=slack_backend),
+        github_client=GithubClient(backend=github_backend),
+        slack_channel_id="C1234",
+        slapr_bot_user_id="U1234",
+        number_of_approvals_required=2,
+        emoji_review_started="test_review_started",
+        emoji_approved="test_approved",
+        emoji_needs_change="test_needs_change",
+        emoji_merged="test_merged",
+        emoji_closed="test_closed",
+        emoji_commented="test_commented",
+        emoji_partially_approved=partial_emoji,
+    )
+    slapr.main(config)
+
+    assert slack_backend.emojis == expected_emojis
+
+
+@pytest.mark.parametrize(
     "event, pr, reactions, expected_emojis",
     [
         pytest.param(


### PR DESCRIPTION
### What does this PR do?

Adds an optional emoji-partially-approved action input. When at least one approval exists but the configured approval threshold has not been reached, Slapr uses that reaction. Once the threshold is met, Slapr replaces it with the configured approved reaction. Changes requested continue to take precedence.

### Motivation

Slapr already supports a configurable approval count, but it does not expose progress toward that count. This lets a workflow use :next_track_button: while approvals are still pending and :ship: when the threshold is met.

### Describe how you validated your changes

- Added tests for partial approval, threshold completion, backward compatibility, comment precedence, and changes-requested precedence.
- All 32 unit tests pass locally.
- The Docker image builds successfully and passes the repository import smoke test.

### Additional Notes

The new input is opt-in and has no default, so existing workflows retain their current behavior. Broader approval-policy configuration is intentionally left for focused follow-up changes.