### PR TITLE
Improve logs when slapr bot is not in a Slack channel.

### DIFF
--- a/slapr/main.py
+++ b/slapr/main.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Set
 from . import emojis
 from .config import Config
 from .github import GithubClient, PullRequest
-from .slack import SlackClient
+from .slack import SlackChannelAccessError, SlackClient
 
 
 def main(config: Config) -> None:
@@ -67,7 +67,7 @@ def main(config: Config) -> None:
         all_channels = config.review_map.get_channels_for_requested_teams(requested_teams)
         already_processed = set(target_channels.keys())
         for channel_id in all_channels - already_processed:
-            print(f"Broadcasting review_started to channel {channel_id}")
+            print(f"Broadcasting review_started to channel {_channel_label(config, channel_id)}")
             _apply_emojis_to_channel(
                 config, slack, {config.emoji_review_started}, pr_url, channel_id
             )
@@ -104,14 +104,23 @@ def _resolve_target_channels(
             target_channels[channel_id].append(team)
         else:
             is_member = reviewer and team.has_in_members(reviewer)
-            print(f"  Team {full_team}: channel={channel_id}, {reviewer.login if reviewer else None} is_member={is_member}")
+            print(
+                f"  Team {full_team}: channel={_channel_label(config, channel_id)}, "
+                f"{reviewer.login if reviewer else None} is_member={is_member}"
+            )
             if is_member:
                 target_channels[channel_id].append(team)
 
     if target_channels:
         return target_channels
-    print(f"No team match, falling back to default channel {config.slack_channel_id}")
+    print(f"No team match, falling back to default channel {_channel_label(config, config.slack_channel_id)}")
     return {config.slack_channel_id: []}
+
+
+def _channel_label(config: Config, channel_id: str) -> str:
+    if config.review_map is not None:
+        return config.review_map.format_channel(channel_id)
+    return channel_id
 
 
 def _apply_emojis_to_channel(
@@ -121,16 +130,27 @@ def _apply_emojis_to_channel(
     pr_url: str,
     channel_id: str,
 ) -> None:
-    timestamp = slack.find_timestamp_of_review_requested_message(pr_url=pr_url, channel_id=channel_id)
-    print(f"Slack message timestamp for channel {channel_id}: {timestamp}")
+    channel_label = _channel_label(config, channel_id)
+    try:
+        timestamp = slack.find_timestamp_of_review_requested_message(pr_url=pr_url, channel_id=channel_id)
+    except SlackChannelAccessError as e:
+        _log_channel_access_error(config, e)
+        raise
+
+    print(f"Slack message timestamp for channel {channel_label}: {timestamp}")
 
     if timestamp is None:
-        print(f"No message found requesting review for PR: {pr_url} in channel {channel_id}")
+        print(f"No message found requesting review for PR: {pr_url} in channel {channel_label}")
         return
 
-    existing_emojis = slack.get_emojis_for_user(
-        timestamp=timestamp, channel_id=channel_id, user_id=config.slapr_bot_user_id
-    )
+    try:
+        existing_emojis = slack.get_emojis_for_user(
+            timestamp=timestamp, channel_id=channel_id, user_id=config.slapr_bot_user_id
+        )
+    except SlackChannelAccessError as e:
+        _log_channel_access_error(config, e)
+        raise
+
     print(f"Existing emojis: {', '.join(existing_emojis)}")
 
     emojis_to_add, emojis_to_remove = emojis.diff(new_emojis=new_emojis, existing_emojis=existing_emojis)
@@ -141,7 +161,26 @@ def _apply_emojis_to_channel(
     print(f"Emojis to remove        : {', '.join(emojis_to_remove)}")
 
     for emoji in sorted_emojis_to_add:
-        slack.add_reaction(timestamp=timestamp, emoji=emoji, channel_id=channel_id)
+        try:
+            slack.add_reaction(timestamp=timestamp, emoji=emoji, channel_id=channel_id)
+        except SlackChannelAccessError as e:
+            _log_channel_access_error(config, e)
+            raise
 
     for emoji in emojis_to_remove:
-        slack.remove_reaction(timestamp=timestamp, emoji=emoji, channel_id=channel_id)
+        try:
+            slack.remove_reaction(timestamp=timestamp, emoji=emoji, channel_id=channel_id)
+        except SlackChannelAccessError as e:
+            _log_channel_access_error(config, e)
+            raise
+
+
+def _log_channel_access_error(config: Config, error: SlackChannelAccessError) -> None:
+    channel_label = _channel_label(config, error.channel_id)
+    if error.error == "not_in_channel":
+        print(
+            f"Error: Slapr bot is not installed in channel {channel_label}. "
+            "Invite the bot to this channel to enable emoji reactions."
+        )
+    else:
+        print(f"Error: Cannot access channel {channel_label}: {error.error}")

--- a/slapr/review_map.py
+++ b/slapr/review_map.py
@@ -20,15 +20,37 @@ DEFAULT_SLACK_CHANNEL = "DEFAULT_SLACK_CHANNEL"
 
 
 class ReviewMap:
-    def __init__(self, team_to_channel: Dict[str, str], default_channel_id: Optional[str]):
+    def __init__(
+        self,
+        team_to_channel: Dict[str, str],
+        default_channel_id: Optional[str],
+        channel_id_to_name: Optional[Dict[str, str]] = None,
+    ):
         """
         Args:
             team_to_channel: Mapping of team names to Slack channel IDs.
                              Keys are lowercase, e.g. "@datadog/agent-apm" -> "C01234".
             default_channel_id: Fallback channel ID when no team matches.
+            channel_id_to_name: Optional mapping of channel IDs to human-readable names.
         """
         self.team_to_channel = team_to_channel
         self.default_channel_id = default_channel_id
+        self.channel_id_to_name = channel_id_to_name or {}
+        self.channel_id_to_teams: Dict[str, List[str]] = {}
+        for team, channel_id in team_to_channel.items():
+            self.channel_id_to_teams.setdefault(channel_id, []).append(team)
+
+    def format_channel(self, channel_id: str) -> str:
+        """Return a human-readable channel label for logs and errors."""
+        name = self.channel_id_to_name.get(channel_id)
+        teams = self.channel_id_to_teams.get(channel_id, [])
+        if name:
+            label = f"#{name} ({channel_id})"
+        else:
+            label = channel_id
+        if teams:
+            label += f" [{', '.join(teams)}]"
+        return label
 
     @staticmethod
     def load(file_path: str, slack_client: "SlackClient", default_channel_id: str) -> "ReviewMap":
@@ -60,6 +82,7 @@ class ReviewMap:
 
         # First pass: extract channel IDs and collect names that need resolution
         team_to_channel = {}
+        channel_id_to_name: Dict[str, str] = {}
         teams_pending_resolve = defaultdict(list)  # {channel_name: [team_key, ...]}
         team_format = re.compile(r"\@[a-zA-Z0-9-_]+\/[a-zA-Z0-9-_]+")
         for team, entry in raw_map.items():
@@ -70,6 +93,9 @@ class ReviewMap:
             match entry:
                 case str() if entry == DEFAULT_SLACK_CHANNEL:
                     team_to_channel[team_key] = default_channel_id
+                case {"review": {"id": str(channel_id), "name": str(channel_name), **_rest}} if channel_id and channel_name:
+                    team_to_channel[team_key] = channel_id
+                    channel_id_to_name[channel_id] = channel_name
                 case {"review": {"id": str(channel_id), **_rest}} if channel_id:
                     team_to_channel[team_key] = channel_id
                 case {"review": {"id": "", **_rest}}:
@@ -99,12 +125,18 @@ class ReviewMap:
 
             for channel_name, team_keys in teams_pending_resolve.items():
                 if channel_name in name_to_id:
+                    channel_id = name_to_id[channel_name]
+                    channel_id_to_name[channel_id] = channel_name
                     for team_key in team_keys:
-                        team_to_channel[team_key] = name_to_id[channel_name]
+                        team_to_channel[team_key] = channel_id
                 else:
                     print(f"Warning: Could not resolve channel '{channel_name}' for teams {', '.join(team_keys)}, skipping")
 
-        return ReviewMap(team_to_channel=team_to_channel, default_channel_id=default_channel_id)
+        return ReviewMap(
+            team_to_channel=team_to_channel,
+            default_channel_id=default_channel_id,
+            channel_id_to_name=channel_id_to_name,
+        )
 
     def get_channels_for_requested_teams(self, requested_teams: List) -> Set[str]:
         """Return all Slack channel IDs for the given requested teams.

--- a/slapr/slack.py
+++ b/slapr/slack.py
@@ -12,6 +12,15 @@ from slack_sdk.errors import SlackApiError
 PR_URL_PATTERN = r"<(?P<url>https?://[^>|]+)(?:\|[^>]*)?>"
 
 
+class SlackChannelAccessError(Exception):
+    """Raised when the Slack bot cannot access a channel."""
+
+    def __init__(self, channel_id: str, error: str) -> None:
+        self.channel_id = channel_id
+        self.error = error
+        super().__init__(f"Slack API error '{error}' for channel {channel_id}")
+
+
 class Message(NamedTuple):
     text: str
     timestamp: str
@@ -44,7 +53,12 @@ class WebSlackBackend(SlackBackend):
         self._client = client
 
     def get_latest_messages(self, channel_id: str) -> List[Message]:
-        response = self._client.conversations_history(channel=channel_id)
+        try:
+            response = self._client.conversations_history(channel=channel_id)
+        except SlackApiError as e:
+            if e.response["error"] == "not_in_channel":
+                raise SlackChannelAccessError(channel_id, "not_in_channel") from e
+            raise
         if not response["ok"]:
             raise RuntimeError(f"conversations_history failed for channel {channel_id}: {response}")
         return [
@@ -54,7 +68,12 @@ class WebSlackBackend(SlackBackend):
         ]
 
     def get_reactions(self, timestamp: str, channel_id: str) -> List[Reaction]:
-        response = self._client.reactions_get(channel=channel_id, timestamp=timestamp)
+        try:
+            response = self._client.reactions_get(channel=channel_id, timestamp=timestamp)
+        except SlackApiError as e:
+            if e.response["error"] == "not_in_channel":
+                raise SlackChannelAccessError(channel_id, "not_in_channel") from e
+            raise
         if not response["ok"]:
             raise RuntimeError(f"reactions_get failed for channel {channel_id}, timestamp {timestamp}: {response}")
 
@@ -70,6 +89,8 @@ class WebSlackBackend(SlackBackend):
         except SlackApiError as e:
             if e.response['error'] == 'already_reacted':
                 print(f'Warning: Message {timestamp} has already emote {emoji} within channel {channel_id}')
+            elif e.response['error'] == 'not_in_channel':
+                raise SlackChannelAccessError(channel_id, "not_in_channel") from e
             else:
                 print(f'Error: reactions_add failed for channel {channel_id}, emoji {emoji}, timestamp {timestamp}: {e}')
                 raise
@@ -78,6 +99,8 @@ class WebSlackBackend(SlackBackend):
         try:
             self._client.reactions_remove(channel=channel_id, name=emoji, timestamp=timestamp)
         except SlackApiError as e:
+            if e.response['error'] == 'not_in_channel':
+                raise SlackChannelAccessError(channel_id, "not_in_channel") from e
             print(f'Error: reactions_remove failed for channel {channel_id}, emoji {emoji}, timestamp {timestamp}: {e}')
             raise
 

--- a/tests/test_review_map.py
+++ b/tests/test_review_map.py
@@ -24,6 +24,21 @@ def _make_slack_client(channel_map):
     return SlackClient(backend=MockSlackBackendForResolve(channel_map))
 
 
+def test_format_channel_with_name_and_teams():
+    review_map = ReviewMap(
+        team_to_channel={
+            "@datadog/agent-apm": "C_APM",
+            "@datadog/agent-build": "C_BUILD",
+        },
+        default_channel_id="C_DEFAULT",
+        channel_id_to_name={"C_APM": "apm-review"},
+    )
+
+    assert review_map.format_channel("C_APM") == "#apm-review (C_APM) [@datadog/agent-apm]"
+    assert review_map.format_channel("C_BUILD") == "C_BUILD [@datadog/agent-build]"
+    assert review_map.format_channel("C_UNKNOWN") == "C_UNKNOWN"
+
+
 def test_load_with_review_name_and_id():
     """When review has both name and id, id is used directly (no API call)."""
     yaml_content = """
@@ -48,6 +63,10 @@ def test_load_with_review_name_and_id():
     assert review_map.team_to_channel == {
         "@datadog/agent-apm": "C_APM",
         "@datadog/agent-build": "C_BUILD",
+    }
+    assert review_map.channel_id_to_name == {
+        "C_APM": "apm-review",
+        "C_BUILD": "agent-build-review",
     }
     assert review_map.default_channel_id == "C_DEFAULT"
 
@@ -74,6 +93,10 @@ def test_load_review_name_only_resolves_via_api():
     assert review_map.team_to_channel == {
         "@datadog/agent-apm": "C_APM",
         "@datadog/agent-build": "C_BUILD",
+    }
+    assert review_map.channel_id_to_name == {
+        "C_APM": "apm-review",
+        "C_BUILD": "agent-build-review",
     }
 
 

--- a/tests/test_slapr.py
+++ b/tests/test_slapr.py
@@ -11,7 +11,7 @@ import slapr
 from slapr.config import Config
 from slapr.github import GithubBackend, GithubClient, PullRequest, Review
 from slapr.review_map import ReviewMap
-from slapr.slack import Message, Reaction, SlackBackend, SlackClient
+from slapr.slack import Message, Reaction, SlackBackend, SlackChannelAccessError, SlackClient
 
 
 # --- Mock GitHub objects (stand-ins for PyGithub types) ---
@@ -601,3 +601,60 @@ def test_review_started_broadcast_to_all_requested_team_channels():
     assert slack_backend.channel_emojis["C_APM"] == ["test_review_started", "test_approved"]
     # agent-build was also requested: should get review_started even though alice is not a member
     assert slack_backend.channel_emojis["C_BUILD"] == ["test_review_started"]
+
+
+class NotInChannelSlackBackend(MockSlackBackend):
+    def get_latest_messages(self, channel_id: str) -> List[Message]:
+        if channel_id == "C_BLOCKED":
+            raise SlackChannelAccessError(channel_id, "not_in_channel")
+        return super().get_latest_messages(channel_id)
+
+
+def test_not_in_channel_logs_channel_name_and_raises(capsys):
+    """When the bot is not in a channel, log a clear message and fail the job."""
+    messages_ok = [Message(text="Need review <https://github.com/example/repo/pull/42>", timestamp="ts-ok")]
+    messages_blocked = [Message(text="Need review <https://github.com/example/repo/pull/42>", timestamp="ts-blocked")]
+
+    slack_backend = NotInChannelSlackBackend(
+        messages=[],
+        target_message=messages_ok[0],
+        reactions=[],
+        channel_messages={"C_OK": messages_ok, "C_BLOCKED": messages_blocked},
+        channel_reactions={"C_OK": [], "C_BLOCKED": []},
+    )
+    github_backend = MockGithubBackend(
+        reviews=[Review(state="approved", user=_user("alice"))],
+        event=MOCK_EVENT_MERGE_WITH_OWNER,
+        pr=PullRequest(state="closed", merged=True, mergeable_state="clean"),
+        requested_teams_timeline=["agent-apm", "agent-build"],
+        team_members={"agent-apm": ["alice"], "agent-build": ["alice"]},
+    )
+
+    review_map = ReviewMap(
+        team_to_channel={"@datadog/agent-apm": "C_OK", "@datadog/agent-build": "C_BLOCKED"},
+        default_channel_id="C_DEFAULT",
+        channel_id_to_name={"C_OK": "apm-review", "C_BLOCKED": "agent-build-review"},
+    )
+
+    config = Config(
+        slack_client=SlackClient(backend=slack_backend),
+        github_client=GithubClient(backend=github_backend),
+        slack_channel_id="C_DEFAULT",
+        slapr_bot_user_id="U1234",
+        number_of_approvals_required=1,
+        emoji_review_started="test_review_started",
+        emoji_approved="test_approved",
+        emoji_needs_change="test_needs_change",
+        emoji_merged="test_merged",
+        emoji_closed="test_closed",
+        emoji_commented="test_commented",
+        review_map=review_map,
+    )
+    with pytest.raises(SlackChannelAccessError) as exc_info:
+        slapr.main(config)
+
+    output = capsys.readouterr().out
+    assert "not installed in channel #agent-build-review (C_BLOCKED) [@datadog/agent-build]" in output
+    assert exc_info.value.channel_id == "C_BLOCKED"
+    assert slack_backend.channel_emojis["C_OK"] == ["test_approved", "test_merged"]
+    assert slack_backend.channel_emojis.get("C_BLOCKED", []) == []


### PR DESCRIPTION
Surface channel names and mapped GitHub teams in error output so CI failures are actionable without cross-referencing the review map, while preserving the existing job failure behavior.

## Summary
- Add human-readable channel labels (name, ID, mapped GitHub teams) to slapr logs and errors when using a review map
- Log a clear actionable message before failing when the bot hits Slack `not_in_channel`
- Preserve existing behavior: the job still crashes so missing bot installs remain visible in CI

## Test plan
- [x] `pytest tests/`
- [ ] Verify a CI run with a `not_in_channel` failure shows the channel name and team in logs before exiting with code 1


