### PR TITLE
Add configurable approval emoji rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,56 @@ Slack API Token with following permissions
 | `SLAPR_EMOJI_MERGED`         | The PR is merged.                                            |
 | `SLAPR_EMOJI_CLOSED`         | The PR is closed.                                            |
 
+## Approval configuration
+
+Use the optional `approval-config` input when you want to map an approval state
+to multiple emojis or suppress an individual state. The built-in approval count
+is normalized into these states:
+
+| state       | description                                                   |
+|-------------|---------------------------------------------------------------|
+| `none`      | No applicable approval, comment, or change request exists.    |
+| `commented` | A comment-only review exists and no stronger state applies.    |
+| `partial`   | At least one approval exists, but the threshold is not met.    |
+| `complete`  | The configured approval threshold is met.                      |
+| `blocked`   | An applicable reviewer has requested changes.                  |
+| `unknown`   | Approval progress cannot be determined by an evaluation source. |
+
+Create a versioned YAML file whose values are ordered lists of Slack emoji names:
+
+```yaml
+# .github/slapr-approvals.yml
+version: 1
+states:
+  none: []
+  commented:
+    - speech_balloon
+  partial:
+    - next_track_button
+    - one
+  complete:
+    - ship
+  blocked:
+    - changes_requested
+  unknown:
+    - question
+```
+
+Then pass the file to the action:
+
+```yaml
+with:
+  approval-config: .github/slapr-approvals.yml
+  number-of-approvals-required: 2
+```
+
+State keys may be omitted or assigned an empty list to suppress their reactions.
+An emoji may only be assigned to one state. When `approval-config` is omitted,
+Slapr translates the existing `emoji-commented`, `emoji-changes-requested`,
+`emoji-partially-approved`, and `emoji-approved` inputs into equivalent rules.
+When it is set, the file replaces those four review-state mappings; lifecycle
+inputs such as `emoji-review-started`, `emoji-merged`, and `emoji-closed` are unchanged.
+
 ## Review Map (multi-channel routing)
 
 By default, slapr posts emoji reactions to a single Slack channel (`SLACK_CHANNEL_ID`). With the `review-map` input, you can route reactions to different Slack channels based on which GitHub teams are requested for review.

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   review-map:
     description: 'Path to a YAML file mapping GitHub teams to Slack channels'
     required: false
+  approval-config:
+    description: 'Path to a YAML file mapping approval states to emoji names'
+    required: false
   number-of-approvals-required:
     description: 'Minimum approvals for "approved" emoji'
     required: false
@@ -56,6 +59,7 @@ runs:
     SLACK_CHANNEL_ID: ${{ inputs.slack-channel-id }}
     SLAPR_BOT_USER_ID: ${{ inputs.bot-user-id }}
     SLAPR_REVIEW_MAP: ${{ inputs.review-map }}
+    SLAPR_APPROVAL_CONFIG: ${{ inputs.approval-config }}
     SLAPR_NUMBER_OF_APPROVALS_REQUIRED: ${{ inputs.number-of-approvals-required }}
     SLAPR_EMOJI_REVIEW_STARTED: ${{ inputs.emoji-review-started }}
     SLAPR_EMOJI_APPROVED: ${{ inputs.emoji-approved }}

--- a/slapr/__main__.py
+++ b/slapr/__main__.py
@@ -8,6 +8,7 @@ import os
 import github
 import slack_sdk
 
+from .approval_config import ApprovalConfig
 from .config import Config
 from .github import GithubClient, WebGithubBackend
 from .main import main
@@ -25,6 +26,11 @@ if review_map_path:
         slack_client=slack_client,
         default_channel_id=os.environ["SLACK_CHANNEL_ID"],
     )
+
+approval_config = None
+approval_config_path = os.environ.get("SLAPR_APPROVAL_CONFIG")
+if approval_config_path:
+    approval_config = ApprovalConfig.load(approval_config_path)
 
 config = Config(
     slack_client=slack_client,
@@ -46,6 +52,7 @@ config = Config(
     emoji_commented=os.environ.get("SLAPR_EMOJI_COMMENTED", "comment"),
     emoji_partially_approved=os.environ.get("SLAPR_EMOJI_PARTIALLY_APPROVED") or None,
     review_map=review_map,
+    approval_config=approval_config,
 )
 
 main(config)

--- a/slapr/approval.py
+++ b/slapr/approval.py
@@ -1,0 +1,57 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/)
+# Copyright 2023-present Datadog, Inc.
+
+from enum import Enum
+from typing import List, NamedTuple, Optional
+
+from .github import Review
+
+
+class ApprovalState(str, Enum):
+    NONE = "none"
+    COMMENTED = "commented"
+    PARTIAL = "partial"
+    COMPLETE = "complete"
+    BLOCKED = "blocked"
+    UNKNOWN = "unknown"
+
+
+class ApprovalProgress(NamedTuple):
+    state: ApprovalState
+    approvals: Optional[int]
+    required: Optional[int]
+
+
+def evaluate(reviewer_teams: List, reviews: List[Review], number_of_approvals_required: int) -> ApprovalProgress:
+    last_review_by_author = {review.user.login: review for review in reviews}
+
+    if reviewer_teams:
+        last_reviews = [
+            review
+            for review in last_review_by_author.values()
+            if any(team.has_in_members(review.user) for team in reviewer_teams)
+        ]
+    else:
+        last_reviews = list(last_review_by_author.values())
+
+    unique_states = {review.state for review in last_reviews}
+    approval_count = len([review for review in last_reviews if review.state == "approved"])
+
+    if "changes_requested" in unique_states:
+        state = ApprovalState.BLOCKED
+    elif approval_count >= number_of_approvals_required:
+        state = ApprovalState.COMPLETE
+    elif approval_count > 0:
+        state = ApprovalState.PARTIAL
+    elif "commented" in unique_states:
+        state = ApprovalState.COMMENTED
+    else:
+        state = ApprovalState.NONE
+
+    return ApprovalProgress(
+        state=state,
+        approvals=approval_count,
+        required=number_of_approvals_required,
+    )

--- a/slapr/approval_config.py
+++ b/slapr/approval_config.py
@@ -1,0 +1,101 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/)
+# Copyright 2023-present Datadog, Inc.
+
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple
+
+import yaml
+
+from .approval import ApprovalState
+
+
+STATE_DISPLAY_ORDER = (
+    ApprovalState.NONE,
+    ApprovalState.COMMENTED,
+    ApprovalState.BLOCKED,
+    ApprovalState.PARTIAL,
+    ApprovalState.COMPLETE,
+    ApprovalState.UNKNOWN,
+)
+
+
+class ApprovalConfig:
+    def __init__(self, emojis_by_state: Mapping[ApprovalState, Sequence[str]]) -> None:
+        self._emojis_by_state: Dict[ApprovalState, Tuple[str, ...]] = {
+            state: tuple(emojis_by_state.get(state, ())) for state in ApprovalState
+        }
+
+    @classmethod
+    def load(cls, file_path: str) -> "ApprovalConfig":
+        with open(file_path, encoding="utf-8") as config_file:
+            raw_config = yaml.safe_load(config_file)
+
+        if not isinstance(raw_config, dict):
+            raise ValueError("approval config must be a mapping")
+
+        unknown_keys = [key for key in raw_config if key not in {"version", "states"}]
+        if unknown_keys:
+            formatted_keys = ", ".join(sorted(str(key) for key in unknown_keys))
+            raise ValueError(f"unknown approval config keys: {formatted_keys}")
+
+        if raw_config.get("version") != 1:
+            raise ValueError("approval config version must be 1")
+
+        raw_states = raw_config.get("states")
+        if not isinstance(raw_states, dict):
+            raise ValueError("approval config states must be a mapping")
+
+        supported_states = {state.value for state in ApprovalState}
+        unknown_states = [state for state in raw_states if not isinstance(state, str) or state not in supported_states]
+        if unknown_states:
+            formatted_states = ", ".join(sorted(str(state) for state in unknown_states))
+            raise ValueError(f"unknown approval states: {formatted_states}")
+
+        emojis_by_state: Dict[ApprovalState, List[str]] = {}
+        state_by_emoji: Dict[str, ApprovalState] = {}
+        for state_name, raw_emojis in raw_states.items():
+            if not isinstance(raw_emojis, list):
+                raise ValueError(f"approval state {state_name!r} must contain a list of emoji names")
+
+            state = ApprovalState(state_name)
+            emojis: List[str] = []
+            for raw_emoji in raw_emojis:
+                if not isinstance(raw_emoji, str) or not raw_emoji.strip() or raw_emoji != raw_emoji.strip():
+                    raise ValueError(f"approval state {state_name!r} contains an invalid emoji name")
+                if raw_emoji in emojis:
+                    raise ValueError(f"approval state {state_name!r} contains duplicate emoji {raw_emoji!r}")
+                if raw_emoji in state_by_emoji:
+                    other_state = state_by_emoji[raw_emoji]
+                    raise ValueError(
+                        f"emoji {raw_emoji!r} is assigned to both {other_state.value!r} and {state_name!r}"
+                    )
+                emojis.append(raw_emoji)
+                state_by_emoji[raw_emoji] = state
+            emojis_by_state[state] = emojis
+
+        return cls(emojis_by_state)
+
+    @classmethod
+    def from_legacy(
+        cls,
+        emoji_commented: str,
+        emoji_needs_change: str,
+        emoji_partially_approved: Optional[str],
+        emoji_approved: str,
+    ) -> "ApprovalConfig":
+        emojis_by_state = {
+            ApprovalState.COMMENTED: [emoji_commented],
+            ApprovalState.BLOCKED: [emoji_needs_change],
+            ApprovalState.COMPLETE: [emoji_approved],
+        }
+        if emoji_partially_approved:
+            emojis_by_state[ApprovalState.PARTIAL] = [emoji_partially_approved]
+        return cls(emojis_by_state)
+
+    def emojis_for(self, state: ApprovalState) -> Tuple[str, ...]:
+        return self._emojis_by_state[state]
+
+    @property
+    def ordered_emojis(self) -> Tuple[str, ...]:
+        return tuple(emoji for state in STATE_DISPLAY_ORDER for emoji in self._emojis_by_state[state])

--- a/slapr/config.py
+++ b/slapr/config.py
@@ -5,6 +5,7 @@
 
 from typing import Callable, NamedTuple, Optional
 
+from .approval_config import ApprovalConfig
 from .github import GithubClient
 from .review_map import ReviewMap
 from .slack import SlackClient
@@ -28,6 +29,18 @@ class Config(NamedTuple):
 
     emoji_partially_approved: Optional[str] = None
     review_map: Optional[ReviewMap] = None
+    approval_config: Optional[ApprovalConfig] = None
+
+    @property
+    def approval_rules(self) -> ApprovalConfig:
+        if self.approval_config is not None:
+            return self.approval_config
+        return ApprovalConfig.from_legacy(
+            emoji_commented=self.emoji_commented,
+            emoji_needs_change=self.emoji_needs_change,
+            emoji_partially_approved=self.emoji_partially_approved,
+            emoji_approved=self.emoji_approved,
+        )
 
     @property
     def emojis_by_review_step(self) -> Callable[[str], int]:
@@ -35,19 +48,8 @@ class Config(NamedTuple):
 
         Suitable for usage with `sorted(...key=...)` or `some_list.sort(key=...)`.
         """
-        review_steps_as_emojis = [
-            self.emoji_review_started,
-            self.emoji_commented,
-            self.emoji_needs_change,
-        ]
-        if self.emoji_partially_approved:
-            review_steps_as_emojis.append(self.emoji_partially_approved)
-        review_steps_as_emojis.extend(
-            [
-                self.emoji_approved,
-                self.emoji_closed,
-                self.emoji_merged,
-            ]
-        )
+        review_steps_as_emojis = [self.emoji_review_started]
+        review_steps_as_emojis.extend(self.approval_rules.ordered_emojis)
+        review_steps_as_emojis.extend([self.emoji_closed, self.emoji_merged])
 
         return lambda emoji: review_steps_as_emojis.index(emoji)

--- a/slapr/emojis.py
+++ b/slapr/emojis.py
@@ -3,10 +3,11 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/)
 # Copyright 2023-present Datadog, Inc.
 
-from typing import List, Optional, Set, Tuple
+from typing import List, Set, Tuple
 
-from .github import Review
+from .approval import evaluate
 from .config import Config
+from .github import Review
 
 
 def select(
@@ -14,37 +15,13 @@ def select(
     reviews: List[Review],
     config: Config,
     number_of_approvals_required: int,
-) -> Optional[str]:
-
-    last_review_by_author = {review.user.login: review for review in reviews}
-
-    # Keep only reviews from authors belonging to the same team(s) as the reviewer
-    if reviewer_teams:
-        last_reviews = [
-            review
-            for review in last_review_by_author.values()
-            if any(team.has_in_members(review.user) for team in reviewer_teams)
-        ]
-    else:
-        # No review map or no team match: consider all reviews
-        last_reviews = list(last_review_by_author.values())
-
-    unique_states = {review.state for review in last_reviews}
-
-    if "changes_requested" in unique_states:
-        return config.emoji_needs_change
-
-    approval_count = len([review.state for review in last_reviews if review.state == "approved"])
-    if ("approved" in unique_states) and approval_count >= number_of_approvals_required:
-        return config.emoji_approved
-
-    if approval_count > 0 and config.emoji_partially_approved:
-        return config.emoji_partially_approved
-
-    if "commented" in unique_states:
-        return config.emoji_commented
-
-    return None
+) -> Set[str]:
+    progress = evaluate(
+        reviewer_teams=reviewer_teams,
+        reviews=reviews,
+        number_of_approvals_required=number_of_approvals_required,
+    )
+    return set(config.approval_rules.emojis_for(progress.state))
 
 
 def diff(new_emojis: Set[str], existing_emojis: Set[str]) -> Tuple[Set[str], Set[str]]:

--- a/slapr/main.py
+++ b/slapr/main.py
@@ -43,7 +43,7 @@ def main(config: Config) -> None:
 
     for channel_id, teams in target_channels.items():
 
-        review_emoji = emojis.select(
+        review_emojis = emojis.select(
             teams,
             reviews,
             config,
@@ -51,8 +51,7 @@ def main(config: Config) -> None:
         )
 
         new_emojis = set() if pr.state == "closed" else {config.emoji_review_started}
-        if review_emoji:
-            new_emojis.add(review_emoji)
+        new_emojis.update(review_emojis)
 
         if pr.merged:
             new_emojis.add(config.emoji_merged)

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -1,0 +1,137 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/)
+# Copyright 2023-present Datadog, Inc.
+
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from slapr.approval import ApprovalState, evaluate
+from slapr.approval_config import ApprovalConfig
+from slapr.github import Review
+
+
+class MockUser:
+    def __init__(self, login: str):
+        self.login = login
+
+
+def _reviews(states: List[str]) -> List[Review]:
+    return [Review(state=state, user=MockUser(f"reviewer-{index}")) for index, state in enumerate(states)]
+
+
+@pytest.mark.parametrize(
+    "states, required, expected_state, expected_approvals",
+    [
+        pytest.param([], 2, ApprovalState.NONE, 0, id="none"),
+        pytest.param(["commented"], 2, ApprovalState.COMMENTED, 0, id="commented"),
+        pytest.param(["approved"], 2, ApprovalState.PARTIAL, 1, id="partial"),
+        pytest.param(["approved", "approved"], 2, ApprovalState.COMPLETE, 2, id="complete"),
+        pytest.param(["approved", "approved", "approved"], 2, ApprovalState.COMPLETE, 3, id="above-threshold"),
+        pytest.param(["approved", "changes_requested"], 2, ApprovalState.BLOCKED, 1, id="blocked"),
+    ],
+)
+def test_evaluate_approval_progress(
+    states: List[str],
+    required: int,
+    expected_state: ApprovalState,
+    expected_approvals: int,
+) -> None:
+    progress = evaluate(
+        reviewer_teams=[],
+        reviews=_reviews(states),
+        number_of_approvals_required=required,
+    )
+
+    assert progress.state == expected_state
+    assert progress.approvals == expected_approvals
+    assert progress.required == required
+
+
+def test_evaluate_uses_latest_review_per_author() -> None:
+    alice = MockUser("alice")
+    bob = MockUser("bob")
+    reviews = [
+        Review(state="approved", user=alice),
+        Review(state="approved", user=bob),
+        Review(state="commented", user=alice),
+    ]
+
+    progress = evaluate(reviewer_teams=[], reviews=reviews, number_of_approvals_required=2)
+
+    assert progress.state == ApprovalState.PARTIAL
+    assert progress.approvals == 1
+
+
+def test_load_approval_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "approval-config.yml"
+    config_path.write_text(
+        """\
+version: 1
+states:
+  partial:
+    - next_track_button
+    - one
+  complete:
+    - ship
+  blocked: []
+""",
+        encoding="utf-8",
+    )
+
+    config = ApprovalConfig.load(str(config_path))
+
+    assert config.emojis_for(ApprovalState.PARTIAL) == ("next_track_button", "one")
+    assert config.emojis_for(ApprovalState.COMPLETE) == ("ship",)
+    assert config.emojis_for(ApprovalState.BLOCKED) == ()
+    assert config.emojis_for(ApprovalState.NONE) == ()
+    assert config.ordered_emojis == ("next_track_button", "one", "ship")
+
+
+@pytest.mark.parametrize(
+    "contents, expected_error",
+    [
+        pytest.param("[]", "must be a mapping", id="root-not-mapping"),
+        pytest.param("version: 2\nstates: {}", "version must be 1", id="unsupported-version"),
+        pytest.param("version: 1\nstates: []", "states must be a mapping", id="states-not-mapping"),
+        pytest.param("version: 1\nstates: {}\nextra: true", "unknown approval config keys: extra", id="unknown-key"),
+        pytest.param("version: 1\nstates:\n  waiting: []", "unknown approval states: waiting", id="unknown-state"),
+        pytest.param(
+            "version: 1\nstates:\n  partial: next_track_button",
+            "must contain a list",
+            id="state-not-list",
+        ),
+        pytest.param(
+            "version: 1\nstates:\n  partial: [ship, ship]",
+            "contains duplicate emoji 'ship'",
+            id="duplicate-in-state",
+        ),
+        pytest.param(
+            "version: 1\nstates:\n  partial: [ship]\n  complete: [ship]",
+            "assigned to both 'partial' and 'complete'",
+            id="duplicate-across-states",
+        ),
+    ],
+)
+def test_invalid_approval_config(tmp_path: Path, contents: str, expected_error: str) -> None:
+    config_path = tmp_path / "approval-config.yml"
+    config_path.write_text(contents, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=expected_error):
+        ApprovalConfig.load(str(config_path))
+
+
+def test_legacy_inputs_create_equivalent_rules() -> None:
+    config = ApprovalConfig.from_legacy(
+        emoji_commented="comment",
+        emoji_needs_change="changes_requested",
+        emoji_partially_approved="next_track_button",
+        emoji_approved="ship",
+    )
+
+    assert config.emojis_for(ApprovalState.COMMENTED) == ("comment",)
+    assert config.emojis_for(ApprovalState.BLOCKED) == ("changes_requested",)
+    assert config.emojis_for(ApprovalState.PARTIAL) == ("next_track_button",)
+    assert config.emojis_for(ApprovalState.COMPLETE) == ("ship",)

--- a/tests/test_slapr.py
+++ b/tests/test_slapr.py
@@ -8,6 +8,8 @@ from typing import Dict, List, Optional, Set
 import pytest
 
 import slapr
+from slapr.approval import ApprovalState
+from slapr.approval_config import ApprovalConfig
 from slapr.config import Config
 from slapr.github import GithubBackend, GithubClient, PullRequest, Review
 from slapr.review_map import ReviewMap
@@ -349,6 +351,44 @@ def test_multiple_approvals(
     slapr.main(config)
 
     assert slack_backend.emojis == expected_emojis
+
+
+def test_approval_config_can_render_multiple_emojis() -> None:
+    messages = [Message(text="Need review <https://github.com/example/repo/pull/42>", timestamp="yyyy-mm-dd")]
+    slack_backend = MockSlackBackend(messages=messages, target_message=messages[0], reactions=[])
+    github_backend = MockGithubBackend(
+        reviews=[Review(state="approved", user=_user("alice"))],
+        event=MOCK_EVENT,
+        pr=PullRequest(state="open", merged=False, mergeable_state="clean"),
+    )
+    approval_config = ApprovalConfig(
+        {
+            ApprovalState.PARTIAL: ["test_partially_approved", "test_one_approval"],
+            ApprovalState.COMPLETE: ["test_approved"],
+        }
+    )
+
+    config = Config(
+        slack_client=SlackClient(backend=slack_backend),
+        github_client=GithubClient(backend=github_backend),
+        slack_channel_id="C1234",
+        slapr_bot_user_id="U1234",
+        number_of_approvals_required=2,
+        emoji_review_started="test_review_started",
+        emoji_approved="test_approved",
+        emoji_needs_change="test_needs_change",
+        emoji_merged="test_merged",
+        emoji_closed="test_closed",
+        emoji_commented="test_commented",
+        approval_config=approval_config,
+    )
+    slapr.main(config)
+
+    assert slack_backend.emojis == [
+        "test_review_started",
+        "test_partially_approved",
+        "test_one_approval",
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?

Adds an optional approval-config action input for a versioned YAML file that maps normalized approval states to ordered lists of Slack reactions. A state can render multiple emojis or be suppressed with an empty list.

Approval evaluation is separated into an ApprovalProgress model with none, commented, partial, complete, blocked, and unknown states. Existing emoji inputs are translated into equivalent implicit rules when no configuration file is supplied.

### Motivation

PR #68 added visible progress for a fixed approval threshold. This follow-up lets teams customize how each approval state is rendered without coupling Slapr to CODEOWNERS, GitHub rulesets, or a particular policy engine.

### Describe how you validated your changes

- Added tests for normalized approval states, latest-review handling, YAML loading, invalid versions and states, conflicting emoji rules, legacy compatibility, and multi-emoji rendering.
- All 51 unit tests pass locally.
- Python compilation and diff checks pass.
- The Docker image builds successfully and passes the repository import smoke test.

### Additional Notes

The new file is opt-in. Existing workflows retain their current behavior when approval-config is omitted. GitHub ruleset and external policy providers remain separate follow-up changes; the unknown state is reserved for evaluation sources that cannot determine progress.